### PR TITLE
chore(docs): fix wrong url in test badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Speed Sleuth 🕵️ [![Tests](https://github.com/lion24/speed-sleuth/actions/workflows/test.yml/badge.svg?branch=main)](https://travis-ci.org/lion24/automated-speedtest) [![codecov](https://codecov.io/gh/lion24/speed-sleuth/graph/badge.svg?token=A4VHEY9KTT)](https://codecov.io/gh/lion24/speed-sleuth)
+Speed Sleuth 🕵️ [![Tests](https://github.com/lion24/speed-sleuth/actions/workflows/test.yml/badge.svg?branch=main)](https://github.com/lion24/speed-sleuth) [![codecov](https://codecov.io/gh/lion24/speed-sleuth/graph/badge.svg?token=A4VHEY9KTT)](https://codecov.io/gh/lion24/speed-sleuth)
 ====
 Automated speedtest analyser using chrome headless feature
 


### PR DESCRIPTION
No more using travis but github actions.