### PR TITLE
feat: allow to run in headless mode

### DIFF
--- a/src/speed_sleuth/browser/chromium.py
+++ b/src/speed_sleuth/browser/chromium.py
@@ -34,6 +34,8 @@ class ChromiumBrowser:
     Attributes:
         binary_path (str, optional): An optional location of the webdriver
             location. Default to None.
+        headless (bool, optional): Run in headless mode, i.e., without a UI
+                or display server dependencies
 
     Methods:
         load_driver(): Creates and returns a configured Selenium WebDriver
@@ -41,8 +43,9 @@ class ChromiumBrowser:
 
     """
 
-    def __init__(self, binary_path=None):
+    def __init__(self, binary_path=None, headless=False):
         self.binary_path = binary_path
+        self.headless = headless
 
     def load_driver(self) -> WebDriver:
         """Initializes and returns a Selenium WebDriver instance configured for
@@ -77,7 +80,8 @@ class ChromiumBrowser:
         chrome_options = options.ChromiumOptions()
         if self.binary_path:
             chrome_options.binary_location = self.binary_path
-        # options.add_argument('--headless')
+        if self.headless:
+            chrome_options.add_argument("--headless")
         chrome_options.add_argument("--window-size=1400x900")
         chrome_options.add_argument("--disable-gpu")
         chrome_options.add_argument("--lang=en_US")

--- a/src/speed_sleuth/browser/ms_edge.py
+++ b/src/speed_sleuth/browser/ms_edge.py
@@ -14,20 +14,18 @@ class MSEdgeBrowser:
     Attributes:
         binary_path (str): The file path to the Microsoft Edge browser
             executable.
+        headless (bool, optional): Run in headless mode, i.e., without a UI
+                or display server dependencies
+
+    Methods:
+        load_driver(): Creates and returns a configured Selenium WebDriver
+            instance for the Chromium browser.
 
     """
 
-    def __init__(self, binary_path=None):
-        """Initializes a new instance of the MSEdgeBrowser with the specified
-        binary path for the Edge browser.
-
-        Parameters:
-            binary_path (str, optional): The file path to the Microsoft Edge
-                browser executable.
-
-        """
-
+    def __init__(self, binary_path=None, headless=False):
         self.binary_path = binary_path
+        self.headless = headless
 
     def load_driver(self) -> WebDriver:
         """Initializes and returns a Selenium WebDriver for Microsoft Edge with
@@ -51,6 +49,8 @@ class MSEdgeBrowser:
 
         if self.binary_path:
             edge_options.binary_location = self.binary_path
+        if self.headless:
+            edge_options.add_argument("--headless")
         edge_options.add_argument("--window-size=1400x900")
         edge_options.add_argument("--disable-gpu")
         edge_options.add_argument("--lang=en_US")

--- a/tests/unit/test_chromium.py
+++ b/tests/unit/test_chromium.py
@@ -1,11 +1,16 @@
 import unittest
 import unittest.mock
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, PropertyMock, call, patch
 
 from speed_sleuth.browser.chromium import ChromiumBrowser
 
 
 class TestChromiumBrowser(unittest.TestCase):
+    def setUp(self):
+        self.chromium_instance = ChromiumBrowser(
+            binary_path="/mock/browser/binary/path", headless=True
+        )
+
     @patch("selenium.webdriver.Chrome")
     @patch("selenium.webdriver.chromium.options.ChromiumOptions")
     @patch("selenium.webdriver.chromium.service.ChromiumService")
@@ -15,27 +20,29 @@ class TestChromiumBrowser(unittest.TestCase):
         mock_driver = MagicMock()
         mock_chrome.return_value = mock_driver
         options_instance = MagicMock()
+        binary_location_mock = PropertyMock()
+        type(options_instance).binary_location = binary_location_mock
         mock_options.return_value = options_instance
         service_instance = MagicMock()
         mock_service.return_value = service_instance
 
-        browser = ChromiumBrowser()
-        browser.load_driver()
+        self.chromium_instance.load_driver()
 
         mock_service.assert_called_once()
         mock_options.assert_called_once()
-        options_instance.add_argument.assert_any_call("--window-size=1400x900")
-        options_instance.add_argument.assert_any_call("--disable-gpu")
-        options_instance.add_argument.assert_any_call("--lang=en_US")
+        binary_location_mock.assert_called_once_with(
+            "/mock/browser/binary/path"
+        )
+        options_instance.add_argument.assert_has_calls(
+            [
+                call("--headless"),
+                call("--window-size=1400x900"),
+                call("--disable-gpu"),
+                call("--lang=en_US"),
+            ],
+            any_order=True,
+        )
 
         mock_chrome.assert_called_once_with(
             service=service_instance, options=options_instance
         )
-
-        browser = None
-
-        # Assert that binary path is correct when initializing
-        browser = ChromiumBrowser("/mock/browser/binary/path")
-        browser.load_driver()
-
-        self.assertEqual("/mock/browser/binary/path", browser.binary_path)


### PR DESCRIPTION
Disabled by default, it is possible to launch a browser in headless mode and thus without a UI or display server dependencies